### PR TITLE
adding unit tests to deleteUrl and creating UrlStore [MA-73]

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "files.associations": {
+        "filesystem": "cpp",
+        "iosfwd": "cpp",
+        "xstring": "cpp"
+    }
+}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,8 @@ add_executable(myProgram
     src/checkUrl.cpp
     src/RepeatableHashFunction.cpp
     src/App.cpp
-    src/main.cpp         
+    src/main.cpp
+    src/UrlStore.cpp         
 )
 
 target_link_libraries(myProgram stdc++fs)
@@ -40,7 +41,10 @@ src/RepeatableHashFunctionTest.cpp
 src/RepeatableHashFunction.cpp
 src/BloomFilterTest.cpp
 src/AppTests.cpp
-src/App.cpp)
+src/App.cpp
+src/delete_url_test.cpp
+src/deleteUrl.cpp
+src/UrlStore.cpp)
 
 target_link_libraries(runTests stdc++fs) # using std::filesystem in c++ 17 
 

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -10,7 +10,10 @@
 
 using namespace std;    
 
-App::App() : filter(nullptr), urlFilePath("/usr/src/mytest/data/urls.txt"), bloomFilePath("/usr/src/mytest/data/bloom.txt"){}
+App::App() 
+    : filter(nullptr),
+      store("/usr/src/mytest/data/urls.txt"),
+      bloomFilePath("/usr/src/mytest/data/bloom.txt") {}
 
 bool App::isValidUrl(const string& url) {
     static const regex urlRegex(R"(^((https?:\/\/)?(www\.)?([a-zA-Z0-9\-]+\.)+[a-zA-Z0-9]{2,})(\/\S*)?$)");
@@ -55,10 +58,10 @@ void App::handleCommand(const string& line) {
     }
 
     if (commandType == 1) {
-        addUrl command(url, *filter, urlFilePath);
+        addUrl command(url, *filter, store);
         command.execute();
     } else if (commandType == 2) {
-        checkUrl command(url, *filter, urlFilePath);
+        checkUrl command(url, *filter, store);
         command.execute();
     } else {
         return;
@@ -82,7 +85,7 @@ void App::run() {
     if (loadedBits.size() > 0) {
         filter->setFilter(loadedBits);
     }
-    
+    store.load();
     string commandLine;
     while (getline(cin, commandLine)) {
         handleCommand(commandLine);

--- a/src/App.h
+++ b/src/App.h
@@ -4,6 +4,7 @@
 #include "BloomFilter.h"
 #include <memory>
 #include <string>
+#include "UrlStore.h"
 using namespace std;
 
 // Main application class to handle URL filtering operations
@@ -11,7 +12,7 @@ class App
 {
 private:
     unique_ptr<BloomFilter> filter;
-    string urlFilePath;
+    UrlStore store;
     string bloomFilePath;
 
     // Initialize the Bloom filter from the given line

--- a/src/UrlStore.cpp
+++ b/src/UrlStore.cpp
@@ -1,0 +1,49 @@
+#include "UrlStore.h"
+#include <fstream>
+#include <iostream>
+using namespace std;
+
+UrlStore::UrlStore(const string& filePath) : filePath(filePath) {}
+
+// Loads all URLs from file into set
+void UrlStore::load() {
+    urls.clear();
+    ifstream in(filePath);
+    string line;
+
+    while (getline(in, line)) {
+        if (!line.empty()) {
+            urls.insert(line);
+        }
+    }
+
+    in.close();
+}
+
+// Saves the set back into the file (one URL per line)
+void UrlStore::save() const {
+    ofstream out(filePath, ios::trunc);
+    for (const auto& url : urls) {
+        out << url << "\n";
+    }
+    out.close();
+}
+
+bool UrlStore::contains(const string& url) const {
+    return urls.find(url) != urls.end();
+}
+
+
+void UrlStore::add(const string& url) {
+    urls.insert(url);
+    save();
+}
+
+bool UrlStore::remove(const std::string& url) {
+    if (urls.erase(url)) {
+        save(); // overwrite the file with updated set
+        return true;
+    }
+    return false;
+}
+

--- a/src/UrlStore.h
+++ b/src/UrlStore.h
@@ -1,0 +1,22 @@
+#ifndef URLSTORE_H
+#define URLSTORE_H
+
+#include <string>
+#include <set>
+
+class UrlStore {
+private:
+    std::set<std::string> urls;
+    std::string filePath;
+
+public:
+    UrlStore(const std::string& filePath);
+
+    void load();              // Loads all URLs from file into the set
+    void save() const;        // Saves current set to file
+    bool remove(const std::string& url);
+    bool contains(const std::string& url) const;
+    void add(const std::string& url);
+};
+
+#endif

--- a/src/addUrl.cpp
+++ b/src/addUrl.cpp
@@ -5,26 +5,19 @@
 #include <fstream>
 using namespace std;
 
-addUrl::addUrl(const std::string& url, BloomFilter& bf, const std::string& file)
-:url(url),filter(bf),file(file) {}
+addUrl::addUrl(const std::string& url, BloomFilter& bf, UrlStore& store)
+:url(url),filter(bf),store(store) {}
 
 // Executes the add URL operation:
-// 1. Sets the relevant bits in the Bloom filter
-// 2. Appends the URL to the file
+// 1. Adds the URL to the store (if not already present)
+// 2. Saves the store to file
+// 3. Sets the relevant bits in the Bloom filter
 void addUrl::execute() {
     vector<int> indexes = filter.getIndexes(url);
     // Set each bit in the Bloom filter
     for (int idx : indexes){
         filter.setBit(idx);
     }
-
-    // Open the file in append mode to add the URL without overwriting existing data
-    std::ofstream file(this->file, std::ios::app); 
-    if (file.is_open()) {
-        file << url << "\n"; // write url followed by newline
-        file.close();
-    } else {
-        // Print error if the file could not be opened
-        std::cerr << "Failed to open urls.txt" << std::endl;
-    }
+    // add the url to the urlstore
+    store.add(url);
 }

--- a/src/addUrl.h
+++ b/src/addUrl.h
@@ -3,16 +3,17 @@
 #include <fstream>
 #include "BloomFilter.h"
 #include "Icommand.h"
+#include "UrlStore.h"
 
 // Class to add a URL to the Bloom Filter
 class addUrl:public Icommand {
 public:
-    // Constructor to initialize URL, Bloom filter, and file path
-    addUrl(const std::string& url, BloomFilter& filter, const std::string& file);
+    // Constructor to initialize URL, Bloom filter, and urlstore
+    addUrl(const std::string& url, BloomFilter& filter, UrlStore& store);
     // Execute the command: add URL to Bloom filter
     void execute();
 private:
     const std::string& url; // URL to be added to the filter
     BloomFilter& filter; // Bloom filter reference
-    const std::string& file; // File to persist the filter and URL list
+    UrlStore& store;  // URL store for file + in-memory set
 };

--- a/src/checkUrl.cpp
+++ b/src/checkUrl.cpp
@@ -5,8 +5,8 @@
 #include <fstream>
 using namespace std;
 
-checkUrl::checkUrl(const std::string& url, BloomFilter& filter, const std::string& file)
-    : url(url), filter(filter), file(file) {}
+checkUrl::checkUrl(const string& url, BloomFilter& filter, const UrlStore& store)
+    : url(url), filter(filter), store(store) {}
 
 // Executes the check: determines if the URL might exist and whether it actually exists in the file
 void checkUrl::execute() {
@@ -22,19 +22,12 @@ void checkUrl::execute() {
         cout << "false" << endl; // Definitely not in the blacklist
     }
     else{
-        // Might be in the blacklist, check actual file
-        cout << (isInUrlFile() ? "true true" : "true false") << endl;
+        // Might be in the blacklist, check actual store
+        std::cout << (isInUrlStore() ? "true true" : "true false") << std::endl;
         }
     }
     
-// Checks if the URL is explicitly listed in the file
-bool checkUrl::isInUrlFile(){
-    ifstream infile(file);
-    string line;
-    while (getline(infile, line)) {
-        if (line == url) {
-            return true;
-        }
-    }
-    return false;
+// Checks if the URL is explicitly listed in the store
+bool checkUrl::isInUrlStore() const {
+    return store.contains(url);
 }

--- a/src/checkUrl.h
+++ b/src/checkUrl.h
@@ -1,19 +1,20 @@
 #pragma once
 #include "BloomFilter.h"
 #include "Icommand.h"
+#include "UrlStore.h"
 #include <string>
 
 // Class to check if a URL is blacklisted in the Bloom filter
 class checkUrl : public Icommand {
 public:
-    checkUrl(const std::string& url, BloomFilter& filter, const std::string& file);
+    checkUrl(const std::string& url, BloomFilter& filter, const UrlStore& store);
     void execute() override;
 
 private:
     std::string url;
     const BloomFilter& filter;
-    const std::string file;
+    const UrlStore& store;
 
     // Check if the URL exists in the file
-    bool isInUrlFile();
+    bool isInUrlStore() const;
 };

--- a/src/deleteUrl.cpp
+++ b/src/deleteUrl.cpp
@@ -1,0 +1,9 @@
+#include "deleteUrl.h"
+
+deleteUrl::deleteUrl(const std::string& url, BloomFilter& filter, UrlStore& store)
+    : url(url), filter(filter), store(store) {}
+
+bool deleteUrl::execute() {
+    // Minimal stub implementation for TDD — causes tests to fail
+    return false;
+}

--- a/src/deleteUrl.h
+++ b/src/deleteUrl.h
@@ -1,0 +1,18 @@
+#ifndef DELETE_URL_H
+#define DELETE_URL_H
+
+#include <string>
+#include "BloomFilter.h"
+#include "UrlStore.h"
+
+class deleteUrl {
+    std::string url;
+    BloomFilter& filter;
+    UrlStore& store;
+
+public:
+    deleteUrl(const std::string& url, BloomFilter& filter, UrlStore& store);
+    bool execute(); // returns true if deletion succeeded
+};
+
+#endif

--- a/src/delete_url_test.cpp
+++ b/src/delete_url_test.cpp
@@ -1,0 +1,108 @@
+#include <gtest/gtest.h>
+#include "deleteUrl.h"
+#include "BloomFilter.h"
+
+#include <fstream>
+#include <algorithm>
+#include <filesystem>
+
+using namespace std;
+
+TEST(DeleteUrlTest, isUrlDeleted){
+    string testFile = "../data/test_urls.txt";
+    filesystem::create_directory("../data");
+
+    // Ensure the file is empty before starting
+    ofstream clear(testFile, ios::trunc);
+    clear.close();
+
+    BloomFilter bf(8, {1}, hash<string>());
+    UrlStore store(testFile);
+    store.load();
+
+    string url = "www.unit-test.com";
+    string url2 = "www.unit-test2.com";
+
+    // Pre-populate the file with two URLs
+    ofstream outfile(testFile);
+    outfile << url << endl;
+    outfile << url2 << endl;
+    outfile.close();
+    store.load();  // Load updated file content into memory
+
+    deleteUrl del(url, bf, store);
+    bool result = del.execute();
+    EXPECT_TRUE(result);
+
+    // Check that the URL was removed from the file
+    ifstream infile(testFile);
+    string line;
+    bool found = false;
+    while (getline(infile, line)) {
+        if (line == url) {
+            found = true;
+            break;
+        }
+    }
+    infile.close();
+    ASSERT_FALSE(found);
+
+    // Check that the URL was also removed from the in-memory set
+    EXPECT_FALSE(store.contains(url));
+
+    std::remove(testFile.c_str());
+}
+
+
+TEST(DeleteUrlTest, UrlNotFoundInFileReturnsFalse){
+    string testFile = "../data/test_urls.txt";
+    filesystem::create_directory("../data");
+
+    // Create and clear file
+    ofstream clear(testFile, ios::trunc);
+    clear.close();
+
+    BloomFilter bf(8, {1}, hash<string>());
+    UrlStore store(testFile);
+
+    string url = "www.unit-test.com";
+    string url2 = "www.unit-test2.com";
+
+    // add url2 only
+    ofstream outfile(testFile);
+    outfile << url2 << endl;
+    outfile.close();
+    store.load();
+
+    deleteUrl del(url, bf, store);
+    bool result = del.execute();
+
+    EXPECT_FALSE(result);
+    EXPECT_TRUE(store.contains(url2));   // url2 should still be there
+    EXPECT_FALSE(store.contains(url));   // url should not have been found
+
+    std::remove(testFile.c_str());
+}
+
+
+TEST(DeleteUrlTest, deleteFromEmptyFileReturnsFalse){
+    string testFile = "../data/test_urls.txt";
+    filesystem::create_directory("../data");
+
+    // Ensure the file is empty
+    ofstream clear(testFile, ios::trunc);
+    clear.close();
+
+    string url = "www.unit-test.com";
+    BloomFilter bf(8, {1}, hash<string>());
+    UrlStore store(testFile);
+    store.load();  // will be empty
+
+    deleteUrl del(url, bf, store);
+    bool result = del.execute();
+
+    EXPECT_FALSE(result);                 // deletion should fail
+    EXPECT_FALSE(store.contains(url));    // store should still not contain the url
+
+    std::remove(testFile.c_str());
+}


### PR DESCRIPTION
Implemented tests for deleteUrl and transitioned URL handling to use a dedicated UrlStore class instead of direct file access.
Summary of changes:
- Created UrlStore class for centralized URL management

- Refactored addUrl, checkUrl, app to use UrlStore

- Wrote unit tests to deleteUrl 





