### PR TITLE
Fix to in single mail view [MA-144]

### DIFF
--- a/src/nodejs_server/controllers/mailsController.js
+++ b/src/nodejs_server/controllers/mailsController.js
@@ -18,7 +18,7 @@ const BlacklistService = require('../services/BlacklistService');
         }
 
         // Authorization check: only sender or recipient can access the mail
-        if (mail.from !== userId && mail.to !== userId) {
+        if (mail.from !== userId && !mail.to.includes(userId)) {
             return res.status(403).json({ error: 'Access denied' });
         }
         res.status(200).json(mail);

--- a/src/react_client/src/components/mail/MailHeader.jsx
+++ b/src/react_client/src/components/mail/MailHeader.jsx
@@ -1,9 +1,28 @@
 import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
 
+function getToLine(mail, currentUserId, recipients = []) {
+  if (!mail || !Array.isArray(mail.to)) return "";
+
+  if (mail.from === currentUserId) {
+    if (mail.to.length === 1 && mail.to[0] === currentUserId) {
+      return "to me";
+    } else {
+      return "to " + mail.to.map(id => {
+        if (id === currentUserId) return "me";
+        const user = recipients.find(u => u.id === id);
+        return user
+          ? `${user.firstName} ${user.lastName} <${user.email}>`
+          : `user ${id}`;
+      }).join(", ");
+    }
+  } else {
+    return "to me";
+  }
+}
 
 
-const MailHeader = ({ mail,sender, onToggleStar, onDelete, onMarkSpam, onLabel }) => {
+const MailHeader = ({ mail,sender,recipients = [], onToggleStar, onDelete, onMarkSpam, onLabel }) => {
   const [starred, setStarred] = useState(mail.isStarred || false);
   const [markedSpam, setMarkedSpam] = useState(mail.isSpam || false);
   const navigate = useNavigate();
@@ -14,9 +33,10 @@ const MailHeader = ({ mail,sender, onToggleStar, onDelete, onMarkSpam, onLabel }
       ? sender.image
       : `${baseUrl}/${sender.image}`
     : null;
+  const currentUserId = mail.owner;
+  const toLine = getToLine(mail, currentUserId, Array.isArray(recipients) ? recipients : []);
 
 
-  
 
   const handleStarToggle = () => {
     setStarred(!starred);
@@ -103,7 +123,7 @@ const MailHeader = ({ mail,sender, onToggleStar, onDelete, onMarkSpam, onLabel }
           <div>
             <div className="fw-bold">{sender ? `${sender.firstName} ${sender.lastName}` : mail.senderName}{" "}
               &lt;{sender?.email}&gt;</div>
-            <div className="text-muted small">to me</div>
+            <div className="text-muted small">{toLine}</div>
           </div>
         </div>
 

--- a/src/react_client/src/components/mail/MailView.jsx
+++ b/src/react_client/src/components/mail/MailView.jsx
@@ -1,9 +1,9 @@
 import React, { useState, useEffect } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate,useParams  } from "react-router-dom";
 import MailHeader from "./MailHeader";
 import MailBody from "./MailBody";
-import { getUserById } from "../../services/api";
-import { toggleStarred, toggleSpam, deleteMail, assignLabelsToMail } from "../../services/api";
+import { toggleStarred, toggleSpam, deleteMail, assignLabelsToMail,getUserById } from "../../services/api";
+import {getMailById} from "../../services/mailsService";
 import { getUserIdFromToken } from "../../services/authService";
 import {fetchLabels } from "../../services/labelsService";
 import LabelSelectorModal from "../mail/LabelSelectorModal";
@@ -12,25 +12,31 @@ import LabelSelectorModal from "../mail/LabelSelectorModal";
 
 
 const MailView = ({ mail: initialMail }) => {
-  const [mail, setMail] = useState(initialMail);
+  const [mail, setMail] = useState(null);
   const [sender, setSender] = useState(null);
   const [, setReceiver] = useState(null);
   const [showLabelModal, setShowLabelModal] = useState(false);
   const [, setLabels] = useState([]);
+  const [recipients, setRecipients] = useState([]);
+  const { id } = useParams();
 
   const navigate = useNavigate();
   
 
   useEffect(() => {
-  if (mail?.from) {
-    getUserById(mail.from).then(setSender).catch(console.error);
-  }
-  const currentUserId = getUserIdFromToken();
-  const isSent = mail.from === currentUserId;
-  if (isSent && mail.to?.[0]) {
-    getUserById(mail.to[0]).then(setReceiver).catch(console.error);
-  }
+    if (!mail) return;
+
+    const currentUserId = getUserIdFromToken();
+    const isSent = mail.from === currentUserId;
+
+    if (mail.from) {
+      getUserById(mail.from).then(setSender).catch(console.error);
+    }
+    if (isSent && mail.to?.[0]) {
+      getUserById(mail.to[0]).then(setReceiver).catch(console.error);
+    }
   }, [mail]);
+
 
   useEffect(() => {
     const loadLabels = async () => {
@@ -44,6 +50,25 @@ const MailView = ({ mail: initialMail }) => {
     loadLabels();
   }, []);
 
+  useEffect(() => {
+    const fetchMail = async () => {
+      try {
+        const data = await getMailById(id);
+        setMail(data);
+      } catch (err) {
+        console.error("Failed to fetch mail:", err);
+      }
+    };
+    fetchMail();
+  }, [id]);
+
+  useEffect(() => {
+    if (mail?.to?.length) {
+      Promise.all(mail.to.map(id => getUserById(id)))
+        .then(setRecipients)
+        .catch(console.error);
+    }
+  }, [mail]);
 
   const handleToggleStar = async (id) => {
     try {
@@ -75,6 +100,10 @@ const MailView = ({ mail: initialMail }) => {
     setShowLabelModal(true);
   };
 
+  
+  if (!mail) {
+  return <p className="text-center mt-5">Loading...</p>;
+  }
 
   return (
     <div className="flex-grow-1 p-4" style={{ minHeight: "100vh", backgroundColor: "#f8f9fa" }}>
@@ -87,6 +116,7 @@ const MailView = ({ mail: initialMail }) => {
           onMarkSpam={handleMarkSpam}
           onDelete={handleMarkDelete}
           sender={sender}
+          recipients={recipients}
         />
         <hr />
         <MailBody content={mail.content} />


### PR DESCRIPTION
corrected authorization check in getMailById to support multiple recipients

Previously used `mail.to !== userId` which failed when `mail.to` is an array.
Now using `!mail.to.includes(userId)` to allow proper access to inbox mails.